### PR TITLE
Split itembox into seperate components

### DIFF
--- a/_includes/button.html
+++ b/_includes/button.html
@@ -1,0 +1,3 @@
+<a class="itembox no-deco {{ include.class }}" href="{{ include.url }}">
+	<div class="ib-item5"><p>{{ include.content }}</p></div>
+</a>

--- a/_includes/card.html
+++ b/_includes/card.html
@@ -1,0 +1,5 @@
+<a class="itembox no-deco" href="{{ include.url }}">
+	<img class="itembox-thumb ib-item1" src='{{ include.item1 }}' alt="">
+	<h3 class="ib-item2">{{ include.item2 }}</h3>
+	<p class="ib-item3">{{ include.item3 }}</p>
+</a>

--- a/_includes/friend.html
+++ b/_includes/friend.html
@@ -1,0 +1,3 @@
+<a class="itembox no-deco" href="{{ include.href }}" style="{% if include.color %}--c: {{ include.color }};{% endif %} {% if include.bg-image %}background-image: url({{ include.bg-image }});{% endif %}">
+	<div class="ib-item5"><p>{{ include.name }}</p></div>
+</a>

--- a/_includes/friend.html
+++ b/_includes/friend.html
@@ -1,3 +1,3 @@
-<a class="itembox no-deco" href="{{ include.href }}" style="{% if include.color %}--c: {{ include.color }};{% endif %} {% if include.bg-image %}background-image: url({{ include.bg-image }});{% endif %}">
+<a class="itembox no-deco" href="{{ include.href }}" style="--c: {{ include.color }};background-image: url({{ include.bg-image }})">
 	<div class="ib-item5"><p>{{ include.name }}</p></div>
 </a>

--- a/_includes/itembox.html
+++ b/_includes/itembox.html
@@ -1,9 +1,0 @@
-<div class="itembox {{ include.class }}" onclick="location.href='{{ include.url }}';" onauxclick="window.open('{{ include.url }}');" style="{% if include.color %}--c: {{ include.color }};{% endif %} {% if include.bg-image %}background-image: url({{ include.bg-image }});{% endif %}">
-	{% if include.item1 %}<div class="ib-item1"><img class="itembox-thumb" src='{{ include.item1 }}' alt=""></div>{% endif %}
-	{% if include.item2 %}<div class="ib-item2"><h3><a href="{{ include.url }}" class="no-deco">{{ include.item2 }}</a></h3></div>{% endif %}
-	{% if include.item3 %}<div class="ib-item3"><p>{{ include.item3 }}</p></div>{% endif %}
-	{% if include.item4 %}<div class="ib-item4"><img class='itembox-thumb' src='{{ include.item4 }}' alt=""></div>{% endif %}
-	{% if include.item5 %}<div class="ib-item5"><p><a href="{{ include.url }}" class="no-deco">{{ include.item5 }}</a></p></div>{% endif %}
-	{% if include.item5-hover %}<div class="ib-item5 hover"><p>{{ include.item5-hover }}</p></div>{% endif %}
-	{% if include.item5-unhover %}<div class="ib-item5 unhover"><p><a href="{{ include.url }}" class="no-deco">{{ include.item5-unhover }}</a></p></div>{% endif %}
-</div>

--- a/_includes/itembox_links.html
+++ b/_includes/itembox_links.html
@@ -1,2 +1,0 @@
-{% capture url %}{{ link.url }}{% endcapture %} {% capture color %}{{ link.bgcolor }}{% endcapture %} {% capture image %}{{ link.image }}{% endcapture %} {% capture unhover %}{{ link.name }}{% endcapture %} {% capture hover %}{{ link.hover }}{% endcapture %}
-{% include itembox.html url=url color=color item4=image item5-hover=hover item5-unhover=unhover %}

--- a/_includes/social.html
+++ b/_includes/social.html
@@ -1,5 +1,0 @@
-<a class="itembox no-deco" href="{{ include.url }}" style="--c: {{ include.bgcolor }}">
-	<div class="ib-item4"><img class='itembox-thumb' src='{{ include.image }}' alt=""></div>
-	<div class="ib-item5 unhover"><p>{{ include.name }}</p></div>
-	<div class="ib-item5 hover"><p>{{ include.hover }}</p></div>
-</a>

--- a/_includes/social.html
+++ b/_includes/social.html
@@ -1,0 +1,5 @@
+<a class="itembox no-deco" href="{{ include.url }}" style="--c: {{ include.bgcolor }}">
+	<div class="ib-item4"><img class='itembox-thumb' src='{{ include.image }}' alt=""></div>
+	<div class="ib-item5 unhover"><p>{{ include.name }}</p></div>
+	<div class="ib-item5 hover"><p>{{ include.hover }}</p></div>
+</a>

--- a/_includes/squarelink.html
+++ b/_includes/squarelink.html
@@ -1,0 +1,5 @@
+<a class="itembox no-deco" href="{{ include.url }}" {% if include.bgcolor %} style="--c: {{ include.bgcolor }}" {%endif%}>
+	<div class="ib-item4"><img class='itembox-thumb' src='{{ include.image }}' alt=""></div>
+	<div class="ib-item5 {%if include.hover%}unhover{%endif%}"><p>{{ include.name }}</p></div>
+	{%if include.hover%}<div class="ib-item5 hover"><p>{{ include.hover }}</p></div>{%endif%}
+</a>

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -18,5 +18,5 @@ layout: default
 <h2>Links</h2>
 {% for link in page.links %}
 	{% capture url %}{{ link[1] }}{% endcapture %}  {% capture title %}{{ link[0] }}{% endcapture %}
-	{% include itembox.html url=url item5=title %}
+	{% include button.html url=url content=title %}
 {% endfor %}

--- a/_sass/panels.sass
+++ b/_sass/panels.sass
@@ -136,8 +136,7 @@ div
 
 .ib-item2
 	grid-column: 2
-	h3
-		margin: 16px 0 0 0
+	margin: 16px 0 0 0
 
 .ib-item3
 	grid-column: 2

--- a/index.md
+++ b/index.md
@@ -24,9 +24,9 @@ layout: default
 
 ## Check out
 <div class="grid-container-3">
-	{% include itembox.html url="/projects/marzipan" item4="/assets/sprites/projects/thumbnail_Marzipan.png" item5="<b>Featured Project</b><br>Marzipan" %}
-	{% include itembox.html url="/projects" item4="/assets/sprites/thumbnail_projects.png" item5="Other Projects" %}
-	{% include itembox.html url="/ocs" item4="/assets/sprites/thumbnail_ocs.png" item5="Original Characters" %}
+	{% include squarelink.html url="/projects/marzipan" image="/assets/sprites/projects/thumbnail_Marzipan.png" name="<b>Featured Project</b><br>Marzipan" %}
+	{% include squarelink.html url="/projects" image="/assets/sprites/thumbnail_projects.png" name="Other Projects" %}
+	{% include squarelink.html url="/ocs" image="/assets/sprites/thumbnail_ocs.png" name="Original Characters" %}
 </div>
 
 

--- a/index.md
+++ b/index.md
@@ -34,6 +34,6 @@ layout: default
 <div class="grid-container-2">
 	{% for link in site.data.links_friends %}
 		{% capture url %}{{ link.url }}{% endcapture %} {% capture color %}{{ link.bgcolor }}{% endcapture %} {% capture bg-image %}{{ link.image }}{% endcapture %} {% capture content %}{{ link.name }}{% endcapture %}
-		{% include itembox.html url=url color=color bg-image=bg-image item5=content %}
+		{% include friend.html href=url color=color bg-image=bg-image name=content %}
 	{% endfor %}
 </div>

--- a/index.md
+++ b/index.md
@@ -15,7 +15,7 @@ layout: default
 	Enjoy your stay !!</p>
 </div>
 
-{% include itembox.html url="/links" class="mobile-span-3" item5="Links to Socials & More" %}
+{% include button.html url="/links" class="mobile-span-3" content="Links to Socials & More" %}
 
 <div class="mobile-hide" style="grid-column: 3; grid-row: 1 / span 2; margin: auto;">
 	<img src="/assets/sprites/licorice_fall.png">

--- a/links.md
+++ b/links.md
@@ -6,12 +6,22 @@ layout: default
 ## Main
 <div class="grid-container-3">
 {% for link in site.data.links_main %}
-{% include itembox_links.html %}
+  {% assign name = link.name %}
+  {% assign hover = link.hover %}
+  {% assign url = link.url %}
+  {% assign image = link.image %}
+  {% assign bgcolor = link.bgcolor %}
+  {% include social.html name=name hover=hover url=url image=image bgcolor=bgcolor %}
 {% endfor %}
 </div>
 ## Misc
 <div class="grid-container-3">
 {% for link in site.data.links_misc %}
-{% include itembox_links.html %}
+  {% assign name = link.name %}
+  {% assign hover = link.hover %}
+  {% assign url = link.url %}
+  {% assign image = link.image %}
+  {% assign bgcolor = link.bgcolor %}
+  {% include social.html name=name hover=hover url=url image=image bgcolor=bgcolor %}
 {% endfor %}
 </div>

--- a/links.md
+++ b/links.md
@@ -11,7 +11,7 @@ layout: default
   {% assign url = link.url %}
   {% assign image = link.image %}
   {% assign bgcolor = link.bgcolor %}
-  {% include social.html name=name hover=hover url=url image=image bgcolor=bgcolor %}
+  {% include squarelink.html name=name hover=hover url=url image=image bgcolor=bgcolor %}
 {% endfor %}
 </div>
 ## Misc
@@ -22,6 +22,6 @@ layout: default
   {% assign url = link.url %}
   {% assign image = link.image %}
   {% assign bgcolor = link.bgcolor %}
-  {% include social.html name=name hover=hover url=url image=image bgcolor=bgcolor %}
+  {% include squarelink.html name=name hover=hover url=url image=image bgcolor=bgcolor %}
 {% endfor %}
 </div>

--- a/ocs.html
+++ b/ocs.html
@@ -6,5 +6,5 @@ layout: default
 {% assign ocs = site.ocs | sort:"order" %}
 {% for oc in ocs %}
 {% capture url %}{{ oc.url }}{% endcapture %} {% capture image %}/assets/sprites/ocs/thumbnail_{{ oc.title | downcase }}.png{% endcapture %} {% capture title %}{{ oc.title }}{% endcapture %} {% capture desc %}{{ oc.desc }}{% endcapture %}
-{% include itembox.html url=url item1=image item2=title item3=desc %}
+{% include card.html url=url item1=image item2=title item3=desc %}
 {% endfor %}

--- a/projects.html
+++ b/projects.html
@@ -4,5 +4,5 @@ layout: default
 ---
 {% for project in site.projects %}
 {% capture url %}{{ project.url }}{% endcapture %} {% capture image %}/assets/sprites/projects/thumbnail_{{ project.title }}.png{% endcapture %} {% capture title %}{{ project.title }}{% endcapture %} {% capture desc %}{{ project.category }} • {{ project.year }}{% endcapture %}
-{% include itembox.html url=url item1=image item2=title item3=desc %}
+{% include card.html url=url item1=image item2=title item3=desc %}
 {% endfor %}


### PR DESCRIPTION
And all of them are `<a>`s!!! Now you can middle click them

ocs.md and projects.md have been renamed to HTML because Markdown inserts a paragraph at the start, breaking the `<a>`s since you can't have a paragraph inside a paragraph